### PR TITLE
Update main.py

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -182,6 +182,11 @@ def process_event(event, device_id):
        GPIO.output(6,GPIO.LOW)
        GPIO.output(5,GPIO.HIGH)
        led.ChangeDutyCycle(100)
+        
+    if event.type == EventType.ON_RECOGNIZING_SPEECH_FINISHED:
+       GPIO.output (5, GPIO.LOW)
+       GPIO.output (6, GPIO.LOW)
+       led.ChangeDutyCycle (0)   
 
     print(event)
 


### PR DESCRIPTION
the correction you made here is not effective:
if (event.type == EventType.ON_CONVERSATION_TURN_FINISHED and
            event.args and not event.args['with_follow_on_turn']):
        GPIO.output(5,GPIO.LOW)
        GPIO.output(6,GPIO.LOW)
        led.ChangeDutyCycle(0)
it is effective instead:
if event.type == EventType.ON_RECOGNIZING_SPEECH_FINISHED:
GPIO.output (5, GPIO.LOW)
GPIO.output (6, GPIO.LOW)
led.ChangeDutyCycle (0)

in this way, after about 8 seconds of silence, the LED stops blinking instead of blinking infinitely.