### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ speaker-test -t wav
 **********************************************************************   
 
 1. Download credentials--->.json file (
-The project is currently on 0.4.3, an update behind the official SDK and hence, do not download the json file from here: https: //developers.google.com/assistant/sdk/guides/library/python/embed/config-dev-project-and-account.
-download your credentials.json from here:
+The project is currently on 0.4.3, an update behind the official SDK and hence, do not download the json file from                        https: //developers.google.com/assistant/sdk/guides/library/python/embed/config-dev-project-and-account.
+Download your credentials.json from here:
 https://console.developers.google.com/apis/credentials )
 
 2. Place the .json file in/home/pi directory **DO NOT RENAME**  

--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ speaker-test -t wav
 **********************************************************************   
 
 1. Download credentials--->.json file (
-waiting for updates, do not download the json file from here: https: //developers.google.com/assistant/sdk/guides/library/python/embed/config-dev-project-and-account.
+The project is currently on 0.4.3, an update behind the official SDK and hence, do not download the json file from here: https: //developers.google.com/assistant/sdk/guides/library/python/embed/config-dev-project-and-account.
 download your credentials.json from here:
-)https://console.developers.google.com/apis/credentials
+https://console.developers.google.com/apis/credentials )
 
 2. Place the .json file in/home/pi directory **DO NOT RENAME**  
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,10 @@ speaker-test -t wav
 ## **CONTINUE after SETTING UP AUDIO**
 **********************************************************************   
 
-1. Download credentials--->.json file (refer to this doc for creating credentials https://developers.google.com/assistant/sdk/develop/python/config-dev-project-and-account)   
+1. Download credentials--->.json file (
+waiting for updates, do not download the json file from here: https: //developers.google.com/assistant/sdk/guides/library/python/embed/config-dev-project-and-account.
+download your credentials.json from here:
+)https://console.developers.google.com/apis/credentials
 
 2. Place the .json file in/home/pi directory **DO NOT RENAME**  
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ speaker-test -t wav
 **********************************************************************   
 
 1. Download credentials--->.json file (
-The project is currently on 0.4.3, an update behind the official SDK and hence, do not download the json file from                        https: //developers.google.com/assistant/sdk/guides/library/python/embed/config-dev-project-and-account.
-Download your credentials.json from here:
+The project is currently on 0.4.3, an update behind the official SDK and hence, **do not** download the json file from                   https: //developers.google.com/assistant/sdk/guides/library/python/embed/config-dev-project-and-account.
+**Download your credentials.json from here:**
 https://console.developers.google.com/apis/credentials )
 
 2. Place the .json file in/home/pi directory **DO NOT RENAME**  


### PR DESCRIPTION

waiting for updates,
I think it's correct for new gassistpi users, specify not to download the credential.json file with the new method but to use https://console.developers.google.com/apis/credentials