### PR TITLE
Notify (replay after me)

### DIFF
--- a/src/actions.py
+++ b/src/actions.py
@@ -358,6 +358,11 @@ def convert_rgb_xy(red,green,blue):
     except UnboundLocalError:
         say("No RGB values given")
 
+#Custom text to speak notification
+def notify_tts(phrase):
+    word=(configuration['Notify_TTS']['command']).lower()
+    voice_notify = phrase.replace(word, "")
+    say(voice_notify)
 
 #Radio Station Streaming
 def radio(phrase):

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -156,6 +156,13 @@ MQTT:
   PSWRD: 'Enter your MQTT PASSWORD here'
   TOPIC: 'ENTER your MQTT TOPIC here'
 
+#Text to speak notifications (replay after me workaround for mqtt).
+#Say: "notify, Hi I'm new to google assistant or send mqtt message: "notify Hi I'm new to google assistant"
+#You can change command word to something else.  
+Notify_TTS:
+  Notify_TTS_Control: 'Enabled'
+  command: 'notify'
+  
 #Radio station declarations. Follow a similar pattern to add your own stations.
 #Google may not pickup the pronunciation of radio station names, hence 'Radio 1' etc is required.
 Radio_stations:

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -157,8 +157,7 @@ MQTT:
   TOPIC: 'ENTER your MQTT TOPIC here'
 
 #Text to speak notifications (replay after me workaround for mqtt).
-#Say: "notify, Hi I'm new to google assistant or send mqtt message: "notify Hi I'm new to google assistant"
-#You can change command word to something else.  
+#You can change command word to something else if your command is mixed with native functions  
 Notify_TTS:
   Notify_TTS_Control: 'Enabled'
   command: 'notify'

--- a/src/main.py
+++ b/src/main.py
@@ -84,6 +84,7 @@ from actions import gender
 from actions import on_ir_receive
 from actions import Youtube_credentials
 from actions import Spotify_credentials
+from actions import notify_tts
 
 try:
     FileNotFoundError
@@ -593,6 +594,10 @@ class Myassistant():
                         YouTube_No_Autoplay(str(usrcmd).lower())
         if (custom_action_keyword['Keywords']['Stop_music'][0]).lower() in str(usrcmd).lower():
             stop()
+        if configuration['Notify_TTS']['Notify_TTS_Control']=='Enabled':
+            if (configuration['Notify_TTS']['command']).lower() in str(usrcmd).lower():
+                self.assistant.stop_conversation()
+                notify_tts(str(usrcmd).lower())
         if configuration['Radio_stations']['Radio_Control']=='Enabled':
             if 'radio'.lower() in str(usrcmd).lower():
                 self.assistant.stop_conversation()


### PR DESCRIPTION
Text to speak notifications (replay after me workaround for mqtt).
Say: "notify, Hi I'm new to google assistant or send mqtt message: "custom notify Hi I'm new to google assistant" GassistPi will replie with "hi i'm new to google assist"
User can change command word to something else if its mixed with native functions in config.yaml