### PR TITLE
Fix youtube_dl version compatibility

### DIFF
--- a/Requirements/GassistPi-pip-requirements.txt
+++ b/Requirements/GassistPi-pip-requirements.txt
@@ -5,7 +5,7 @@ kodi-json>=1.0.0
 gmusicapi>=11.1.1
 gTTS==2.0.2
 gTTS-token==1.1.3
-youtube_dl>=2018.11.23
+youtube_dl==2018.11.23
 PyChromecast>=2.3.0
 pafy>=0.5.4
 psutil>=5.4.8


### PR DESCRIPTION
Hey @shivasiddharth ,
Thank you very much for a great work! It saves a lot of time and efforts to run Google assistant on RPi3B+  and Google Voice kit (my case). These installation scripts depend on several packages. Unfortunately, the youtube_dl is not compatible anymore with its previous versions. Running your scripts in early 2019 gives the following: 
```
from .lazy_extractors import *
ImportError: No module named 'youtube_dl.extractor.lazy_extractors'
```
So, if we set a version of the youtube_dl package to exactly 2018.11.23, everything works like a charm.
Please, keep up a great work! 
Regards,
Anton