### PR TITLE
Update gassist-installer.sh

### DIFF
--- a/scripts/gassist-installer.sh
+++ b/scripts/gassist-installer.sh
@@ -139,7 +139,7 @@ if [[ $osversion != "Raspbian Stretch" ]];then
   echo "==========Installing Swig========="
   echo ""
   if [ ! -d /home/${USER}/programs/libraries/swig/ ]; then
-    sudo mkdir -p programs/libraries/ && cd programs/libraries
+    sudo mkdir -p /home/${USER}/programs/libraries/ && cd /home/${USER}/programs/libraries
     sudo git clone https://github.com/swig/swig.git
   fi
   cd /home/${USER}/programs/libraries/swig/


### PR DESCRIPTION
Hi 

There is an error in the file when the installer is creatiin folder then I get an error when I try to enter this folder as the proper path is missing so i believe that /home/${USER}/ needs to be added