### PR TITLE
Prevent crash when radio station is not found

### DIFF
--- a/src/actions.py
+++ b/src/actions.py
@@ -381,15 +381,19 @@ def notify_tts(phrase):
 
 #Radio Station Streaming
 def radio(phrase):
+    conv = None
     for num, name in reversed(list(enumerate(stnname))):
         if name.lower() in phrase:
             station=stnlink[num]
             conv=stnradio[num]
             print (station)
             break
-    say("Tuning into " + conv)
-    vlcplayer.media_manager(station,'Radio')
-    vlcplayer.media_player(station)
+    if conv is not None:
+        say("Tuning into " + conv)
+        vlcplayer.media_manager(station,'Radio')
+        vlcplayer.media_player(station)
+    else:
+        say("Station not found")
 
 
 #ESP6266 Devcies control


### PR DESCRIPTION
Example: In German "Radio 1" gets detected as "Radioeins" if you speak too fast and it crashes the whole app